### PR TITLE
Fix how fatals in `Query_Args` class are caught

### DIFF
--- a/classes/class-init.php
+++ b/classes/class-init.php
@@ -155,9 +155,7 @@ final class Init extends PMC_WP_CLI {
 		} while ( $found_ids !== $this->_count_ids_to_keep() );
 
 		if ( $found_ids < 1 ) {
-			WP_CLI::error(
-				'No IDs were found. Please check the logs.'
-			);
+			WP_CLI::error( 'No IDs were found. Please check the logs.' );
 		}
 
 		WP_CLI::line(


### PR DESCRIPTION
This partially reverts 26757be, moving the try-catch to where the fatal actually arises.