### PR TITLE
Remove certain tables created by VIP features that aren't active locally

### DIFF
--- a/classes/class-customizations.php
+++ b/classes/class-customizations.php
@@ -134,6 +134,8 @@ final class Customizations {
 				'wp_vip_search_index_queue',
 			] as $table
 		) {
+			// Direct queries are necessary as WPDB does not provide a method to drop tables. Table names cannot be interpolated.
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			$wpdb->query( "DROP TABLE IF EXISTS {$table}" );
 		}
 	}


### PR DESCRIPTION
Tables are superfluous, and in the case of the `wp_vip_search_index_queue` table, it uses a collation that was introduced in MySQL 8 and may not be supported by developers' local environments, many of which still use MariaDB.