### PR TITLE
Copy cache-delete operation added to Rewrite Rules Inspector in v1.4.0

### DIFF
--- a/classes/class-customizations.php
+++ b/classes/class-customizations.php
@@ -180,6 +180,7 @@ final class Customizations {
 	public function flush_rewrites(): void {
 		WP_CLI::line( ' * Flushing rewrite rules.' );
 
+		wp_cache_delete( 'rewrite_rules', 'options' );
 		// Used in CLI context.
 		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.flush_rewrite_rules_flush_rewrite_rules
 		flush_rewrite_rules( false );


### PR DESCRIPTION
Added in https://github.com/Automattic/Rewrite-Rules-Inspector/pull/28. v1.4.0 is used on non-production VIP environments as of 2024-06-04: https://wpvipchangelog.wordpress.com/2024/06/04/staging-release-2024-06-04/.