### PR TITLE
Force script to exit upon successful completion

### DIFF
--- a/classes/class-init.php
+++ b/classes/class-init.php
@@ -94,6 +94,7 @@ final class Init extends PMC_WP_CLI {
 			}
 
 			WP_CLI::line( 'Process complete.' );
+			exit( 0 );
 		} catch ( Throwable $throwable ) {
 			$this->_handle_error( $throwable );
 		}


### PR DESCRIPTION
For as-yet-unknown reasons, we've experienced a few runs that "hang" after the `Process complete.` line is output.