### PR TITLE
PUB-583 | Replace per-row PHP operations with bulk SQL for performance

### DIFF
--- a/classes/class-clean-db.php
+++ b/classes/class-clean-db.php
@@ -96,7 +96,8 @@ final class Clean_DB {
 			$wpdb->query( "DELETE FROM `{$wpdb->postmeta}` WHERE post_id IN ({$ids_in})" );
 			$wpdb->query( "DELETE FROM `{$wpdb->term_relationships}` WHERE object_id IN ({$ids_in})" );
 			$wpdb->query(
-				"DELETE FROM `{$wpdb->commentmeta}` WHERE comment_id IN ( SELECT comment_ID FROM `{$wpdb->comments}` WHERE post_id IN ({$ids_in}) )"
+				"DELETE FROM `{$wpdb->commentmeta}` WHERE comment_id IN"
+				. " ( SELECT comment_ID FROM `{$wpdb->comments}` WHERE post_id IN ({$ids_in}) )"
 			);
 			$wpdb->query( "DELETE FROM `{$wpdb->comments}` WHERE post_id IN ({$ids_in})" );
 			$wpdb->query( "DELETE FROM `{$wpdb->posts}` WHERE ID IN ({$ids_in})" );

--- a/classes/class-clean-db.php
+++ b/classes/class-clean-db.php
@@ -91,11 +91,13 @@ final class Clean_DB {
 				)
 			);
 
-			$ids_in = implode( ',', array_map( 'intval', $ids ) );
+			$ids_in = implode( ',', array_map( 'intval', (array) $ids ) );
 
 			$wpdb->query( "DELETE FROM `{$wpdb->postmeta}` WHERE post_id IN ({$ids_in})" );
 			$wpdb->query( "DELETE FROM `{$wpdb->term_relationships}` WHERE object_id IN ({$ids_in})" );
-			$wpdb->query( "DELETE FROM `{$wpdb->commentmeta}` WHERE comment_id IN ( SELECT comment_ID FROM `{$wpdb->comments}` WHERE post_id IN ({$ids_in}) )" );
+			$wpdb->query(
+				"DELETE FROM `{$wpdb->commentmeta}` WHERE comment_id IN ( SELECT comment_ID FROM `{$wpdb->comments}` WHERE post_id IN ({$ids_in}) )"
+			);
 			$wpdb->query( "DELETE FROM `{$wpdb->comments}` WHERE post_id IN ({$ids_in})" );
 			$wpdb->query( "DELETE FROM `{$wpdb->posts}` WHERE ID IN ({$ids_in})" );
 

--- a/classes/class-clean-db.php
+++ b/classes/class-clean-db.php
@@ -16,7 +16,6 @@ declare( strict_types = 1 );
 namespace PMC\WP_Local_Data_CLI;
 
 use WP_CLI;
-use WP_Post;
 use WPCOM_VIP_Cache_Manager;
 
 /**
@@ -92,18 +91,13 @@ final class Clean_DB {
 				)
 			);
 
-			foreach ( $ids as $id_to_delete ) {
-				$deleted = wp_delete_post( $id_to_delete, true );
+			$ids_in = implode( ',', array_map( 'intval', $ids ) );
 
-				if ( ! $deleted instanceof WP_Post ) {
-					WP_CLI::warning(
-						sprintf(
-							'     - Failed to delete post ID `%1$d`',
-							$id_to_delete
-						)
-					);
-				}
-			}
+			$wpdb->query( "DELETE FROM `{$wpdb->postmeta}` WHERE post_id IN ({$ids_in})" );
+			$wpdb->query( "DELETE FROM `{$wpdb->term_relationships}` WHERE object_id IN ({$ids_in})" );
+			$wpdb->query( "DELETE FROM `{$wpdb->commentmeta}` WHERE comment_id IN ( SELECT comment_ID FROM `{$wpdb->comments}` WHERE post_id IN ({$ids_in}) )" );
+			$wpdb->query( "DELETE FROM `{$wpdb->comments}` WHERE post_id IN ({$ids_in})" );
+			$wpdb->query( "DELETE FROM `{$wpdb->posts}` WHERE ID IN ({$ids_in})" );
 
 			$this->_free_resources();
 
@@ -168,29 +162,12 @@ final class Clean_DB {
 
 		WP_CLI::line( " * Removing PII from {$wpdb->users}." );
 
-		foreach (
-			$wpdb->get_col( "SELECT ID FROM {$wpdb->users};" ) as $user_id
-		) {
-			$wpdb->update(
-				$wpdb->users,
-				[
-					'user_email' => sprintf(
-						'user-%1$d@%2$s',
-						$user_id,
-						LOCAL_DOMAIN
-					),
-				],
-				[
-					'ID' => $user_id,
-				],
-				[
-					'user_email' => '%s',
-				],
-				[
-					'ID' => '%d',
-				]
-			);
-		}
+		$wpdb->query(
+			$wpdb->prepare(
+				"UPDATE `{$wpdb->users}` SET user_email = CONCAT('user-', ID, '@', %s)",
+				LOCAL_DOMAIN
+			)
+		);
 	}
 
 	/**

--- a/classes/class-query.php
+++ b/classes/class-query.php
@@ -94,67 +94,83 @@ final class Query {
 			$args
 		);
 
-		$query = new WP_Query( $query_args );
+		$buffer = [];
+		$query  = new WP_Query( $query_args );
 
 		do {
 			foreach ( $query->posts as $id ) {
-				$this->_write_id_to_db( $id, get_post_type( $id ) );
+				$buffer[] = [ 'ID' => $id, 'post_type' => get_post_type( $id ) ];
 
 				if ( has_blocks( $id ) ) {
 					$ids = ( new Gutenberg( $id ) )->get_ids();
 					foreach ( $ids as $gutenberg_id ) {
-						$this->_write_id_to_db(
-							$gutenberg_id['ID'],
-							$gutenberg_id['post_type']
-						);
+						$buffer[] = $gutenberg_id;
 					}
 				}
 
-				if ( null === $callback ) {
-					continue;
+				if ( null !== $callback ) {
+					foreach (
+						$callback( $id, get_post_type( $id ) ) as $entry
+					) {
+						$buffer[] = $entry;
+					}
 				}
 
-				foreach (
-					$callback( $id, get_post_type( $id ) ) as $entry
-				) {
-					$this->_write_id_to_db( $entry['ID'], $entry['post_type'] );
+				if ( count( $buffer ) >= 500 ) {
+					$this->_flush_buffer( $buffer );
+					$buffer = [];
 				}
 			}
 
 			$query_args['paged']++;
 			$query = new WP_Query( $query_args );
 		} while ( $query->have_posts() );
+
+		if ( ! empty( $buffer ) ) {
+			$this->_flush_buffer( $buffer );
+		}
 	}
 
 	/**
-	 * Save to custom database table the post IDs to retain.
+	 * Flush a buffer of ID/post_type pairs to the keep table in one INSERT.
 	 *
-	 * @param int    $id        Post ID.
-	 * @param string $post_type Post type.
+	 * @param array $buffer Array of ['ID' => int, 'post_type' => string].
 	 * @return void
 	 */
-	private function _write_id_to_db( int $id, string $post_type ): void {
+	private function _flush_buffer( array $buffer ): void {
 		global $wpdb;
 
-		if ( 'any' === $post_type ) {
-			$post_type = get_post_type( $id );
+		$rows        = [];
+		$placeholders = [];
+
+		foreach ( $buffer as $entry ) {
+			$id        = (int) $entry['ID'];
+			$post_type = $entry['post_type'];
+
+			if ( 'any' === $post_type ) {
+				$post_type = get_post_type( $id );
+			}
+
+			// TODO: how do we end up with empty `post_type`?
+			if ( empty( $id ) || empty( $post_type ) ) {
+				continue;
+			}
+
+			$rows[]         = $id;
+			$rows[]         = $post_type;
+			$placeholders[] = '(%d, %s)';
 		}
 
-		// TODO: how do we end up with empty `post_type`?
-		if ( empty( $id ) || empty( $post_type ) ) {
+		if ( empty( $placeholders ) ) {
 			return;
 		}
 
-		$wpdb->insert(
-			Init::TABLE_NAME,
-			[
-				'ID'        => $id,
-				'post_type' => $post_type,
-			],
-			[
-				'ID'        => '%d',
-				'post_type' => '%s',
-			]
+		$wpdb->query(
+			$wpdb->prepare(
+				'INSERT IGNORE INTO ' . Init::TABLE_NAME . ' (ID, post_type) VALUES '
+				. implode( ', ', $placeholders ),
+				...$rows
+			)
 		);
 	}
 }

--- a/classes/class-query.php
+++ b/classes/class-query.php
@@ -100,9 +100,9 @@ final class Query {
 		do {
 			foreach ( $query->posts as $id ) {
 				$buffer[] = [
-				'ID'        => $id,
-				'post_type' => get_post_type( $id ),
-			];
+					'ID'        => $id,
+					'post_type' => get_post_type( $id ),
+				];
 
 				if ( has_blocks( $id ) ) {
 					$ids = ( new Gutenberg( $id ) )->get_ids();
@@ -169,8 +169,9 @@ final class Query {
 		}
 
 		$table = Init::TABLE_NAME;
-		$sql   = 'INSERT IGNORE INTO ' . $table . ' (ID, post_type) VALUES ' // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-			. implode( ', ', $placeholders );
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		$sql   = 'INSERT IGNORE INTO ' . $table . ' (ID, post_type) VALUES '
+				. implode( ', ', $placeholders );
 
 		$wpdb->query( // phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
 			$wpdb->prepare( $sql, ...$rows ) // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared

--- a/classes/class-query.php
+++ b/classes/class-query.php
@@ -170,7 +170,7 @@ final class Query {
 
 		$table = Init::TABLE_NAME;
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-		$sql   = 'INSERT IGNORE INTO ' . $table . ' (ID, post_type) VALUES '
+		$sql = 'INSERT IGNORE INTO ' . $table . ' (ID, post_type) VALUES '
 				. implode( ', ', $placeholders );
 
 		$wpdb->query( // phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber

--- a/classes/class-query.php
+++ b/classes/class-query.php
@@ -99,7 +99,10 @@ final class Query {
 
 		do {
 			foreach ( $query->posts as $id ) {
-				$buffer[] = [ 'ID' => $id, 'post_type' => get_post_type( $id ) ];
+				$buffer[] = [
+				'ID'        => $id,
+				'post_type' => get_post_type( $id ),
+			];
 
 				if ( has_blocks( $id ) ) {
 					$ids = ( new Gutenberg( $id ) )->get_ids();
@@ -140,7 +143,7 @@ final class Query {
 	private function _flush_buffer( array $buffer ): void {
 		global $wpdb;
 
-		$rows        = [];
+		$rows         = [];
 		$placeholders = [];
 
 		foreach ( $buffer as $entry ) {
@@ -165,12 +168,12 @@ final class Query {
 			return;
 		}
 
-		$wpdb->query(
-			$wpdb->prepare(
-				'INSERT IGNORE INTO ' . Init::TABLE_NAME . ' (ID, post_type) VALUES '
-				. implode( ', ', $placeholders ),
-				...$rows
-			)
+		$table = Init::TABLE_NAME;
+		$sql   = 'INSERT IGNORE INTO ' . $table . ' (ID, post_type) VALUES ' // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+			. implode( ', ', $placeholders );
+
+		$wpdb->query( // phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+			$wpdb->prepare( $sql, ...$rows ) // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 		);
 	}
 }


### PR DESCRIPTION
Fixes PUB-583.

## Problem
`wp pmc-local-data start` hangs and runs too slowly on large production databases inside Docker on EC2:

- `_delete_posts()` calls `wp_delete_post()` once per post (500/batch), firing all WordPress hooks, cache operations, and multiple queries per call — causes memory exhaustion and hangs
- `_clean_users_table()` issues one `UPDATE` per user row in a loop
- `_write_id_to_db()` issues one `INSERT` per ID, causing thousands of individual DB round-trips and `Duplicate entry` errors

## Changes
- **`class-clean-db.php` — `_delete_posts()`**: Replace `wp_delete_post()` per-row with 5 bulk SQL `DELETE` statements per batch across `postmeta`, `term_relationships`, `commentmeta`, `comments`, and `posts`
- **`class-clean-db.php` — `_clean_users_table()`**: Replace per-row `UPDATE` loop with a single `UPDATE ... SET user_email = CONCAT('user-', ID, '@', domain)`
- **`class-query.php`**: Replace `_write_id_to_db()` single `INSERT` per call with `_flush_buffer()` that accumulates up to 500 rows and writes them with one `INSERT IGNORE ... VALUES (...),(...),...`

## Testing
Baseline run on `main` observed hanging in ID gathering phase for 1.5+ hours with continuous `Duplicate entry` DB errors. This PR addresses the root causes directly.